### PR TITLE
Support notebooks spawned from jupyterhub

### DIFF
--- a/src/proxy/jupyter-http-proxy-middleware.ts
+++ b/src/proxy/jupyter-http-proxy-middleware.ts
@@ -69,7 +69,7 @@ export class JupyterHttpProxyMiddleware extends ProxyMiddleWare{
 
 
   private getInstanceNotebookSessionFromRequest(url: string): InstanceNotebookSession {
-    const regex = '^\\/jupyter\\/(\\d+)\\/api\\/kernels\\/([a-f0-9-]+).*session_id=([a-f0-9-]+).*$';
+    const regex = '^\\/jupyter\\/(\\d+)\\/(?:lab\\/user\\/[a-z0-9]+\\/)?api\\/kernels\\/([a-f0-9-]+).*session_id=([a-f0-9-]+).*$';
     const match = url.match(regex)
     if (match != null && match.length >= 3) {
       const instanceId = Number(match[1]);


### PR DESCRIPTION
In order to give more flexibility to our users to spawn their custom environments, we are using jupyterhub instead of jupyter lab in our visa instances.

We noticed that the running kernels are not displayed in the admin interface anymore.

This comes down to a slightly different request path that the visa-jupyter-server regex fails to catch.

For jupyter lab we have:
```
/jupyter/<instance_id>/api/kernels/<some_kernel_id>/channels?session_id=<some_session_id>
```
and for jupyterhub:
```
/jupyter/<instance_id>/lab/user/<user_id>/api/kernels/<some_kernel_id>/channels?session_id=<some_session_id>
```

I modified the existing regex  to handle both cases.